### PR TITLE
make setglucosetimestamp a function, and go back to grepping openaps.ini

### DIFF
--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -223,6 +223,9 @@ do
         else
             die "Could not run oref0-autotune-core autotune.$run_number.$i.json profile.json profile.pump.json"
         fi
+    else
+        # Copy tuned profile produced by autotune to profile.json for use with next day of data
+        cp newprofile.$run_number.$i.json profile.json
     fi
 
   done # End Date Range Iteration

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -30,7 +30,7 @@ var round_basal = require('./round-basal');
 
     var suggestedRate = round_basal(rate, profile);
     if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
-        rT.reason += currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
+        rT.reason += " "+currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -535,11 +535,17 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.carbsReq = carbsReq;
         rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
     }
-    // low glucose suspend mode: BG is < ~80 and IOB > 20m worth of basal
-    if (bg < threshold && iob_data.iob > profile.current_basal*sens*20/60) {
-        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
+    // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
+    if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
+        rT.reason += "IOB "+iob_data.iob+" < " + round(-profile.current_basal*20/60,2);
+        rT.reason += " and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
+    }
+    // low glucose suspend mode: BG is < ~80
+    else if (bg < threshold) {
+        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile);
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
+            rT.reason += ", minDelta " + minDelta + " < " + "expectedDelta " + expectedDelta + "; ";
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
         if (glucose_status.delta > minDelta) {
@@ -567,7 +573,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
             }
             if (glucose_status.delta > minDelta) {
-                rT.reason += ", but Delta " + tick + " > Exp. Delta " + expectedDelta;
+                rT.reason += ", but Delta " + tick + " > expectedDelta " + expectedDelta;
             } else {
                 rT.reason += ", but Min. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
             }


### PR DESCRIPTION
I don't want to rely on the contents of runagain, as that may not always exist, or may get modified without actually being run, which shouldn't change the behavior of the loop.  So this changes everything back to do `grep "MDT cgm" openaps.ini` to detect a MDT cgm config, and also pulls out all the repetitive new code into a function.